### PR TITLE
Update the default constructor to allow multiple content payloads in a single unit of work

### DIFF
--- a/pegacorn-platform-petasos-model/src/main/java/net/fhirfactory/pegacorn/petasos/model/uow/UoWPayload.java
+++ b/pegacorn-platform-petasos-model/src/main/java/net/fhirfactory/pegacorn/petasos/model/uow/UoWPayload.java
@@ -21,10 +21,11 @@
  */
 package net.fhirfactory.pegacorn.petasos.model.uow;
 
-import net.fhirfactory.pegacorn.common.model.FDN;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.fhirfactory.pegacorn.common.model.FDN;
+import net.fhirfactory.pegacorn.common.model.RDN;
 import net.fhirfactory.pegacorn.petasos.model.topics.TopicToken;
 
 /**
@@ -35,9 +36,15 @@ public class UoWPayload {
     private TopicToken payloadTopicID;
     private String payload;
 
+
     public UoWPayload() {
-        payload = null;
-        payloadTopicID = null;
+        payload = "Empty Payload";
+        TopicToken emptyPayloadToken = new TopicToken();
+        FDN emptyFDN = new FDN();
+        emptyFDN.appendRDN(new RDN("Null", "Null"));
+        emptyPayloadToken.setIdentifier(emptyFDN.getToken());
+        emptyPayloadToken.setVersion("0.0.0");
+        payloadTopicID = emptyPayloadToken;
     }
 
     public UoWPayload(UoWPayload originalUoWPayload) {


### PR DESCRIPTION
The stock usage form POST request payload allows the data for multiple URNs to be submitted in a single request but techone have said they will only ever send one but after speaking with Mark it is a good idea to support multiple.

The constructor of UoWPayload needed updating as a NullPointerException was being thrown.